### PR TITLE
Adding invoice to gcp compacted filenames

### DIFF
--- a/parquet-compactor/parquet_compactor.py
+++ b/parquet-compactor/parquet_compactor.py
@@ -185,15 +185,13 @@ class S3ParquetCompactor:
     ) -> None:
         """Return a boolean whether files were successfully merged"""
         success = True
+        invoice_month = file_list[0].split("_")[0].split("/")[-1]
         dates = sorted({f.split("_")[1] for f in file_list})
         files_per_date = {}
         for date in dates:
             files = [f for f in file_list if date in f]
             files_per_date[date] = files
         for date, file_list in files_per_date.items():
-            invoice_month = datetime.datetime.strptime(
-                date, "%Y-%m-%d"
-            ).strftime("%Y%m")
             msg = (
                 f"GCP: For {date}, reading {len(file_list)}"
                 f" number of files from S3: {file_list}"

--- a/parquet-compactor/parquet_compactor.py
+++ b/parquet-compactor/parquet_compactor.py
@@ -185,13 +185,15 @@ class S3ParquetCompactor:
     ) -> None:
         """Return a boolean whether files were successfully merged"""
         success = True
-        invoice_month = file_list[0].split("_")[0]
         dates = sorted({f.split("_")[1] for f in file_list})
         files_per_date = {}
         for date in dates:
             files = [f for f in file_list if date in f]
             files_per_date[date] = files
         for date, file_list in files_per_date.items():
+            invoice_month = datetime.datetime.strptime(
+                date, "%Y-%m-%d"
+            ).strftime("%Y%m")
             msg = (
                 f"GCP: For {date}, reading {len(file_list)}"
                 f" number of files from S3: {file_list}"
@@ -203,7 +205,8 @@ class S3ParquetCompactor:
                 chunked=CHUNKED_ROWS,
             ):
                 file_path = (
-                    f"{invoice_month}_{date}_{s3_path}{file_name}{uuid.uuid4().hex}.parquet"
+                    f"{s3_path}{invoice_month}_{date}"
+                    f"_{uuid.uuid4().hex}.parquet"
                 )
                 try:
                     msg = f"Combining files. Writing file {file_path}"

--- a/parquet-compactor/parquet_compactor.py
+++ b/parquet-compactor/parquet_compactor.py
@@ -185,6 +185,7 @@ class S3ParquetCompactor:
     ) -> None:
         """Return a boolean whether files were successfully merged"""
         success = True
+        invoice_month = file_list[0].split("_")[0]
         dates = sorted({f.split("_")[1] for f in file_list})
         files_per_date = {}
         for date in dates:
@@ -202,7 +203,7 @@ class S3ParquetCompactor:
                 chunked=CHUNKED_ROWS,
             ):
                 file_path = (
-                    f"{s3_path}{file_name}_{date}_{uuid.uuid4().hex}.parquet"
+                    f"{invoice_month}_{date}_{s3_path}{file_name}{uuid.uuid4().hex}.parquet"
                 )
                 try:
                     msg = f"Combining files. Writing file {file_path}"


### PR DESCRIPTION
This change will continue to allow our masu purge endpoint to still wipe out s3 files + manifests for a particular day